### PR TITLE
Release 0.0.0.3

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -1,7 +1,6 @@
 ﻿<Application x:Class="VideoCompressorGUI.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:VideoCompressorGUI"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
         <ResourceDictionary>

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
-using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
+using VideoCompressorGUI.Utils.Logger;
 
 namespace VideoCompressorGUI
 {
@@ -13,5 +10,23 @@ namespace VideoCompressorGUI
     /// </summary>
     public partial class App : Application
     {
+        private Log logger = new();
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            base.OnStartup(e);
+            SetupExceptionHandling();
+        }
+
+        private void SetupExceptionHandling()
+        {
+            AppDomain.CurrentDomain.UnhandledException += (s, e) =>
+                logger.Error((Exception)e.ExceptionObject);
+
+            DispatcherUnhandledException += (s, e) =>
+                logger.Error(e.Exception);
+
+            TaskScheduler.UnobservedTaskException += (s, e) =>
+                logger.Error(e.Exception);
+        }
     }
 }

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -14,6 +14,9 @@ namespace VideoCompressorGUI
         protected override void OnStartup(StartupEventArgs e)
         {
             base.OnStartup(e);
+#if DEBUG
+            logger.LogToFile = false;
+#endif
             SetupExceptionHandling();
         }
 

--- a/ContentControls/Components/VideoBrowser.xaml.cs
+++ b/ContentControls/Components/VideoBrowser.xaml.cs
@@ -10,9 +10,9 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
 using FFmpeg.NET;
-using ffmpegCompressor;
 using VideoCompressorGUI.ffmpeg;
 using VideoCompressorGUI.Utils;
+using VideoCompressorGUI.Utils.Logger;
 
 namespace VideoCompressorGUI.ContentControls.Components
 {
@@ -113,7 +113,7 @@ namespace VideoCompressorGUI.ContentControls.Components
                 {
                     var path = Path.GetDirectoryName(newFile);
                     Console.ForegroundColor = ConsoleColor.Yellow;
-                    Console.WriteLine("Adding Watcher to: " + path);
+                    Log.Info("Adding watcher to: " + path);
                     Console.ResetColor();
                     FileSystemWatcher watcher = new FileSystemWatcher(path);
 
@@ -137,7 +137,7 @@ namespace VideoCompressorGUI.ContentControls.Components
                         if (refCount == 0)
                         {
                             Console.ForegroundColor = ConsoleColor.Yellow;
-                            Console.WriteLine("Remove watcher: " + watcherToRemove.Watcher.Path);
+                            Log.Info("Remove watcher: " + watcherToRemove.Watcher.Path);
                             Console.ResetColor();
 
                             fileSystemWatchers.Remove(watcherToRemove);
@@ -221,7 +221,6 @@ namespace VideoCompressorGUI.ContentControls.Components
         {
             if (target == null)
             {
-                Console.WriteLine("Removing item was null");
                 return this.videoFileMetaData.Count;
             }
 
@@ -233,7 +232,7 @@ namespace VideoCompressorGUI.ContentControls.Components
                 if (refCount is 0)
                 {
                     Console.ForegroundColor = ConsoleColor.Yellow;
-                    Console.WriteLine("Remove watcher: " + watcherToRemove.Watcher.Path);
+                    Log.Info("Remove watcher: " + watcherToRemove.Watcher.Path);
                     Console.ResetColor();
                     
                     fileSystemWatchers.Remove(watcherToRemove);

--- a/ContentControls/Components/VideoBrowser.xaml.cs
+++ b/ContentControls/Components/VideoBrowser.xaml.cs
@@ -125,7 +125,10 @@ namespace VideoCompressorGUI.ContentControls.Components
                     watcher.Deleted += (sender, args) =>
                     {
                         var watcherToRemove =
-                            fileSystemWatchers.First(t => t.Watcher.Path == Path.GetDirectoryName(args.FullPath));
+                            fileSystemWatchers.FirstOrDefault(t => t.Watcher.Path == Path.GetDirectoryName(args.FullPath));
+
+                        if (watcherToRemove == null) return;
+                        
                         uint refCount = watcherToRemove.Decrease();
 
                         Dispatcher.Invoke(() =>

--- a/ContentControls/Components/VideoPlayer.xaml.cs
+++ b/ContentControls/Components/VideoPlayer.xaml.cs
@@ -113,6 +113,7 @@ namespace VideoCompressorGUI.ContentControls.Components
             }
 
             this.currentlySelectedVideo = association;
+            this.videoPlaybackSlider.ResetThumbs();
             this.videoPlayer.Source = new Uri(association.File);
 
             isPlayingVideo = false;
@@ -130,7 +131,7 @@ namespace VideoCompressorGUI.ContentControls.Components
 
             videoPlayerParent.Visibility = Visibility.Visible;
         }
-
+        
         #region Video playback
 
         private void UpdateDistanceForTextSpan(double _)

--- a/ContentControls/Components/VideoPlayer.xaml.cs
+++ b/ContentControls/Components/VideoPlayer.xaml.cs
@@ -4,7 +4,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Threading;
 using VideoCompressorGUI.Keybindings;
-using VideoCompressorGUI.Settings;
+using VideoCompressorGUI.SettingsLoadables;
 using VideoCompressorGUI.Utils;
 
 namespace VideoCompressorGUI.ContentControls.Components

--- a/ContentControls/Components/VideoRangeSlider.xaml
+++ b/ContentControls/Components/VideoRangeSlider.xaml
@@ -5,16 +5,18 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              mc:Ignorable="d"
              Background="Transparent"
-             d:DesignHeight="30" d:DesignWidth="500" Loaded="VideoRangeSlider_OnLoaded">
+             d:DesignHeight="90" d:DesignWidth="500" Loaded="VideoRangeSlider_OnLoaded">
     <Grid x:Name="parent">
         <Grid.RowDefinitions>
             <RowDefinition />
             <RowDefinition />
+            <RowDefinition />
         </Grid.RowDefinitions>
-        
-        <Thumb PreviewMouseUp="UIElement_OnPreviewMouseUp"  DragStarted="MainThumb_OnDragStarted"
+
+        <!-- BACKGROUND -->
+        <Thumb PreviewMouseUp="UIElement_OnPreviewMouseUp" DragStarted="MainThumb_OnDragStarted"
                DragCompleted="MainThumb_OnDragCompleted"
-               Grid.Row="0" Grid.RowSpan="2">
+               Grid.Row="0">
             <Thumb.OpacityMask>
                 <LinearGradientBrush StartPoint="1, 1" EndPoint="1, 0">
                     <GradientStop Color="#313131" Offset="1.0" />
@@ -22,51 +24,105 @@
                 </LinearGradientBrush>
             </Thumb.OpacityMask>
             <Thumb.Background>
-                <ImageBrush Opacity="0.1" ViewportUnits="Absolute" Viewport="0, 0, 42, 42" ImageSource="https://thumbs.dreamstime.com/b/diagonal-lines-pattern-grey-stripe-texture-background-repeat-straight-line-vector-illustration-154721512.jpg" TileMode="Tile" />
+                <ImageBrush Opacity="0.1" ViewportUnits="Absolute" Viewport="0, 0, 42, 42"
+                            ImageSource="https://thumbs.dreamstime.com/b/diagonal-lines-pattern-grey-stripe-texture-background-repeat-straight-line-vector-illustration-154721512.jpg"
+                            TileMode="Tile" />
             </Thumb.Background>
         </Thumb>
-        
-        <Grid x:Name="lineParent" Grid.Row="0">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="8" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition x:Name="textColumnDefinition" Width="30" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="8" />
-            </Grid.ColumnDefinitions>
-            <Rectangle Grid.Column="0" Margin="3, 0, 0, 0" Width="2" Height="7" VerticalAlignment="Bottom" Fill="{DynamicResource PrimaryHueDarkBrush}" />
-            <Rectangle Grid.Column="1" Margin="-3, 0, -3, 0" Height="2" Fill="{DynamicResource PrimaryHueMidBrush}"></Rectangle>
-            <Rectangle Grid.Column="3" Margin="-3, 0, -3, 0" Height="2" Fill="{DynamicResource PrimaryHueMidBrush}"></Rectangle>
-            <Rectangle Grid.Column="4" Margin="0, 0, 3, 0" Width="2" Height="7" VerticalAlignment="Bottom" Fill="{DynamicResource PrimaryHueMidBrush}" />
-            
-            <TextBlock Grid.Column="2"  HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="9" Text="00:23" x:Name="spanTextBlock" Foreground="{DynamicResource PrimaryHueDarkForegroundBrush}" />
-        </Grid>
-        
-        <Border Grid.Row="2" x:Name="sliderParent" HorizontalAlignment="Stretch" BorderBrush="{DynamicResource PrimaryHueMidBrush}" BorderThickness="10, 2, 10, 2">
+
+        <!-- LEFT RIGHT AND MIDDLE DRAG -->
+        <Border ClipToBounds="False" Grid.Row="0" x:Name="sliderParent" HorizontalAlignment="Stretch"
+                BorderBrush="{DynamicResource PrimaryHueMidBrush}" BorderThickness="2, 2, 2, 2">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="4" />
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="4" />
                 </Grid.ColumnDefinitions>
-                <Thumb Grid.Column="0" x:Name="lowerThumb" DragDelta="Thumb_LowerDragDelta" Margin="-7, 0, 7, 0" Background="{DynamicResource PrimaryHueLightBrush}"></Thumb>
-                <Thumb DragStarted="MidThumb0_OnDragStarted" DragCompleted="MidThumb0_OnDragCompleted" Grid.Column="1" x:Name="midThumb0" DragDelta="Thumb_MidDragDelta" Margin="-4, 0, -4, 0" Background="{DynamicResource PrimaryHueLightBrush}"></Thumb>
-                <Thumb Grid.Column="2" x:Name="upperThumb" DragDelta="Thumb_UpperDragDelta" Margin="7, 0, -7, 0" Background="{DynamicResource PrimaryHueLightBrush}"/>
+                <Thumb Grid.Column="0" x:Name="lowerThumb" DragDelta="Thumb_LowerDragDelta">
+                    <Thumb.Template>
+                        <ControlTemplate>
+                            <Grid>
+                                <Rectangle HorizontalAlignment="Left" Fill="#e7d250" Width="4" />
+                            </Grid>
+                        </ControlTemplate>
+                    </Thumb.Template>
+                </Thumb>
+                <Thumb DragStarted="MidThumb0_OnDragStarted" DragCompleted="MidThumb0_OnDragCompleted" Grid.Column="1"
+                       x:Name="midThumb0" DragDelta="Thumb_MidDragDelta" Margin="0, 0, 0, 0"
+                       Background="{DynamicResource PrimaryHueLightBrush}">
+                </Thumb>
+                <Thumb Grid.Column="2" x:Name="upperThumb" DragDelta="Thumb_UpperDragDelta">
+                    <Thumb.Template>
+                        <ControlTemplate>
+                            <Grid>
+                                <Rectangle HorizontalAlignment="Right" Fill="#e7d250" Width="4" />
+                            </Grid>
+                        </ControlTemplate>
+                    </Thumb.Template>
+                </Thumb>
             </Grid>
         </Border>
-        
-        <Thumb Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Left" x:Name="mainThumb"
+
+        <Grid x:Name="lineParent" Grid.Row="1" Margin="0, 0, 0, 0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="8" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="8" />
+            </Grid.ColumnDefinitions>
+            <Thumb Grid.Column="0" DragDelta="Thumb_LowerDragDelta">
+                <Thumb.Template>
+                    <ControlTemplate>
+                        <Grid>
+                            <Rectangle Fill="#e7d250" Width="4" Height="3" VerticalAlignment="Top" />
+                            <Ellipse Width="8" Height="8" Fill="#e7d250" Margin="0, 2, 0, 0" VerticalAlignment="Top" />
+                        </Grid>
+                    </ControlTemplate>
+                </Thumb.Template>
+            </Thumb>
+            <Thumb Grid.Column="2" DragDelta="Thumb_UpperDragDelta">
+                <Thumb.Template>
+                    <ControlTemplate>
+                        <Grid>
+                            <Rectangle Fill="#e7d250" Width="4" Height="3" VerticalAlignment="Top" />
+                            <Ellipse Width="8" Height="8" Fill="#e7d250" Margin="0, 2, 0, 0"
+                                     VerticalAlignment="Top" />
+                        </Grid>
+                    </ControlTemplate>
+                </Thumb.Template>
+            </Thumb>
+        </Grid>
+
+        <!-- MAIN VALUE -->
+        <Thumb Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Left" x:Name="mainThumb"
                DragDelta="MainThumb_DragDelta"
                DragStarted="MainThumb_OnDragStarted"
                DragCompleted="MainThumb_OnDragCompleted">
             <Thumb.Template>
                 <ControlTemplate>
-                    <Ellipse HorizontalAlignment="Center" VerticalAlignment="Center" Width="10" Height="10" Fill="{DynamicResource PrimaryHueDarkBrush}" />
+                    <Rectangle Fill="#e7d250" HorizontalAlignment="Center" VerticalAlignment="Stretch" Width="5" Height="25" />
                 </ControlTemplate>
             </Thumb.Template>
         </Thumb>
-        
-        <Rectangle Margin="0, 0, 0, 0" x:Name="anchorLeft" HorizontalAlignment="Left" IsHitTestVisible="False" Width="2"></Rectangle>
-        <Rectangle Margin="0, 0, 0, 0" x:Name="anchorRight" HorizontalAlignment="Right" IsHitTestVisible="False" Width="2"></Rectangle>
+
+        <Grid Grid.Row="3" x:Name="textParent">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="22" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="22" />
+            </Grid.ColumnDefinitions>
+            
+            <TextBlock x:Name="lowerThumbText" Grid.Column="0" FontSize="9" Text="99:99"
+                       Foreground="{DynamicResource PrimaryHueDarkForegroundBrush}" />
+            <TextBlock x:Name="upperThumbText" Grid.Column="2" FontSize="9" TextAlignment="Right" Text="99:99"
+                       Foreground="{DynamicResource PrimaryHueDarkForegroundBrush}" />
+        </Grid>
+
+        <Rectangle Margin="0, 0, 0, 0" x:Name="anchorLeft" HorizontalAlignment="Left" IsHitTestVisible="False"
+                   Width="2">
+        </Rectangle>
+        <Rectangle Margin="0, 0, 0, 0" x:Name="anchorRight" HorizontalAlignment="Right" IsHitTestVisible="False"
+                   Width="2">
+        </Rectangle>
     </Grid>
 </UserControl>

--- a/ContentControls/Components/VideoRangeSlider.xaml.cs
+++ b/ContentControls/Components/VideoRangeSlider.xaml.cs
@@ -65,6 +65,23 @@ namespace VideoCompressorGUI.ContentControls.Components
             MainWindow instance = (MainWindow)Application.Current.MainWindow;
             instance.OnWindowSizeChanged += (e) => { CalculateMinimalMaximalPixelValues(); };
         }
+        
+        public void ResetThumbs()
+        {
+            Point lowerThumbPoint =
+                lowerThumb.TransformToAncestor(parent).Transform(new Point(0, 0));
+            Point upperThumbPoint =
+                upperThumb.TransformToAncestor(parent).Transform(new Point(0, 0));
+            
+            sliderParent.Margin = new Thickness(0, 0, 0, 0);
+            lineParent.Margin = new Thickness(0, 0, 0, 0);
+            
+            ValidateDistanceForTextSpan(upperThumbPoint.X - lowerThumbPoint.X);
+            CalculatePercentages();
+            
+            this.OnLowerThumbChanged?.Invoke(this.LowerThumb);
+            this.OnUpperThumbChanged?.Invoke(this.UpperThumb);
+        }
 
         private void VideoRangeSlider_OnLoaded(object sender, RoutedEventArgs e)
         {

--- a/ContentControls/Components/VideoRangeSlider.xaml.cs
+++ b/ContentControls/Components/VideoRangeSlider.xaml.cs
@@ -17,6 +17,7 @@ namespace VideoCompressorGUI.ContentControls.Components
 
 
         public int MinimalThumbDistance => 20;
+        public int MinimalTextDistance => 44;
 
         // Determines, if the value can be changed, when the value drag is active 
         public bool BlockValueOverrideOnDrag { get; set; }
@@ -75,8 +76,7 @@ namespace VideoCompressorGUI.ContentControls.Components
             
             sliderParent.Margin = new Thickness(0, 0, 0, 0);
             lineParent.Margin = new Thickness(0, 0, 0, 0);
-            
-            ValidateDistanceForTextSpan(upperThumbPoint.X - lowerThumbPoint.X);
+            textParent.Margin = new Thickness(0, 0, 0, 0);
             CalculatePercentages();
             
             this.OnLowerThumbChanged?.Invoke(this.LowerThumb);
@@ -147,12 +147,13 @@ namespace VideoCompressorGUI.ContentControls.Components
             {
                 sliderParent.Margin = new Thickness(sliderParent.Margin.Left, 0, value, 0);
                 lineParent.Margin = new Thickness(lineParent.Margin.Left, 0, value, 0);
+
+                if (value < maximalPixelValue - lowerThumbPoint.X - MinimalTextDistance)
+                    textParent.Margin = new Thickness(textParent.Margin.Left, 0, value, 0);
             }
 
 
             this.ClampingRight = value == 0.0d;
-
-            ValidateDistanceForTextSpan(upperThumbPoint.X - lowerThumbPoint.X);
             CalculatePercentages();
 
             this.OnUpperThumbChanged?.Invoke(this.UpperThumb);
@@ -173,31 +174,19 @@ namespace VideoCompressorGUI.ContentControls.Components
             {
                 sliderParent.Margin = new Thickness(value, 0, sliderParent.Margin.Right, 0);
                 lineParent.Margin = new Thickness(value, 0, lineParent.Margin.Right, 0);
+
+                if (value < upperThumbPoint.X - MinimalTextDistance)
+                    textParent.Margin = new Thickness(value, 0, textParent.Margin.Right, 0);
             }
 
 
             this.ClampingLeft = value == 0.0d;
 
-            ValidateDistanceForTextSpan(upperThumbPoint.X - lowerThumbPoint.X);
             CalculatePercentages();
 
             this.OnLowerThumbChanged?.Invoke(this.LowerThumb);
 
             return this.ClampingLeft;
-        }
-
-        private void ValidateDistanceForTextSpan(double distance)
-        {
-            if (distance < this.minimalDistance)
-            {
-                this.spanTextBlock.Visibility = Visibility.Collapsed;
-                this.textColumnDefinition.Width = new GridLength(0);
-            }
-            else
-            {
-                this.spanTextBlock.Visibility = Visibility.Visible;
-                this.textColumnDefinition.Width = new GridLength(30);
-            }
         }
 
         private void SetValueThumb(double v)

--- a/ContentControls/Dialogs/CompressOptionDialog.xaml
+++ b/ContentControls/Dialogs/CompressOptionDialog.xaml
@@ -9,112 +9,162 @@
              d:DesignHeight="200" d:DesignWidth="800"
              Loaded="CompressOptionDialog_OnLoaded">
     <materialDesign:Card MouseDown="OutsideDialog_OnPreviewMouseDown"
-                                 Visibility="Visible"
-                                 Background="#aa313131">
-                <Grid MouseDown="InsideDialog_OnClick">
+                         Visibility="Visible"
+                         Background="#aa313131">
+        <Grid MouseDown="InsideDialog_OnClick">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*" />
+                <ColumnDefinition Width="5*" />
+                <ColumnDefinition Width="3*" />
+            </Grid.ColumnDefinitions>
+
+            <materialDesign:Card Background="{DynamicResource MaterialDesignDarkBackground}" Grid.Row="1"
+                                 Grid.Column="1">
+                <Grid>
                     <Grid.RowDefinitions>
-                        <RowDefinition Height="*" />
+                        <RowDefinition Height="*" MinHeight="35" MaxHeight="45" />
                         <RowDefinition Height="Auto" />
-                        <RowDefinition Height="*" />
                     </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="3*"/>
-                        <ColumnDefinition Width="5*"/>
-                        <ColumnDefinition Width="3*"/>
-                    </Grid.ColumnDefinitions>
-                    
-                    <materialDesign:Card Background="{DynamicResource MaterialDesignDarkBackground}" Grid.Row="1" Grid.Column="1">
+
+                    <!-- Header -->
+                    <materialDesign:Card FontSize="16" Grid.Row="0" Background="{DynamicResource PrimaryHueDarkBrush}">
+                        <TextBlock VerticalAlignment="Center" HorizontalAlignment="Center"
+                                   Text="Letzte Komprimierungoptionen" />
+                    </materialDesign:Card>
+
+                    <StackPanel Grid.Row="1">
+                        <Grid Margin="0, 15, 10, 20">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="30" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <materialDesign:PackIcon Grid.Column="0"
+                                                     Kind="Folder" HorizontalAlignment="Center"
+                                                     VerticalAlignment="Center" />
+
+                            <Grid Grid.Column="1">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <TextBox Margin="0, 0, 5, 0" Grid.Column="0" x:Name="folderPathTextBox"
+                                         PreviewMouseUp="OnSelectFolderPath" IsReadOnly="True"
+                                         materialDesign:HintAssist.Hint="Zielordner" />
+
+                                <TextBox Focusable="True" Margin="0, 0, 5, 0" Grid.Column="1" x:Name="filenameTextBox"
+                                         materialDesign:HintAssist.Hint="Dateiname" TextChanged="OnFileNameChanged">
+                                    <TextBox.Text>
+                                        <Binding
+                                            RelativeSource="{RelativeSource Self}" Path="Text"
+                                            UpdateSourceTrigger="LostFocus">
+                                            <Binding.ValidationRules>
+                                                <validationRules:ValidFileNameValidationRule
+                                                    x:Name="validFileNameValidationRule"
+                                                    ValidatesOnTargetUpdated="True" />
+                                            </Binding.ValidationRules>
+                                        </Binding>
+                                    </TextBox.Text>
+                                </TextBox>
+
+                                <TextBox Grid.Column="2" Text=".mp4" x:Name="fileEndingTextBox" IsEnabled="false"
+                                         IsReadOnly="True" materialDesign:HintAssist.Hint="Format" />
+                            </Grid>
+                        </Grid>
+                        <!-- Ask later questions -->
+                        <Grid x:Name="targetSizeQuestionParent">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="30" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <materialDesign:PackIcon Margin="0, 0, 5, 20" Grid.Column="0"
+                                                     Kind="Numbers" HorizontalAlignment="Center"
+                                                     VerticalAlignment="Center" />
+
+                            <TextBox x:Name="targetSizeTextbox" Grid.Column="1" Margin="0, 0, 10, 20"
+                                     materialDesign:HintAssist.Hint="Zielgröße der Datei"
+                                     TextChanged="TargetSizeTextbox_OnTextChanged">
+                                <TextBox.Text>
+                                    <Binding
+                                        RelativeSource="{RelativeSource Self}" Path="Text"
+                                        UpdateSourceTrigger="LostFocus">
+                                        <Binding.ValidationRules>
+                                            <validationRules:IsDigitValidationRule x:Name="isDigitValidationRule"
+                                                ValidatesOnTargetUpdated="True" />
+                                        </Binding.ValidationRules>
+                                    </Binding>
+                                </TextBox.Text>
+                            </TextBox>
+                        </Grid>
+                        <!-- Control buttons -->
+                        <StackPanel HorizontalAlignment="Right" Margin="0, 0, 10, 10" Orientation="Horizontal">
+                            <Button x:Name="dialogCompressButton" Click="DialogCompress_OnClick" Margin="0, 0, 5, 0">
+                                <StackPanel Orientation="Horizontal">
+                                    <materialDesign:PackIcon VerticalAlignment="Center" HorizontalAlignment="Center"
+                                                             Kind="Compress" />
+                                    <TextBlock Text="Komprimiere..."></TextBlock>
+                                </StackPanel>
+                            </Button>
+                            <Button Click="DialogCancel_OnClick">
+                                <StackPanel Orientation="Horizontal">
+                                    <materialDesign:PackIcon VerticalAlignment="Center" HorizontalAlignment="Center"
+                                                             Kind="Close" />
+                                    <TextBlock Text="Abbrechen"></TextBlock>
+                                </StackPanel>
+                            </Button>
+                        </StackPanel>
+                    </StackPanel>
+                    <materialDesign:Card x:Name="mappingSuggestion" Visibility="Collapsed" Grid.Row="0" Grid.RowSpan="2">
                         <Grid>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="*" MinHeight="35" MaxHeight="45" />
                                 <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*"/>
                             </Grid.RowDefinitions>
-                            
+
                             <!-- Header -->
-                            <materialDesign:Card FontSize="16" Grid.Row="0" Background="{DynamicResource PrimaryHueDarkBrush}">
-                                <TextBlock VerticalAlignment="Center" HorizontalAlignment="Center" Text="Letzte Komprimierungoptionen"/>
+                            <materialDesign:Card FontSize="16" Grid.Row="0"
+                                                 Background="{DynamicResource PrimaryHueDarkBrush}">
+                                <TextBlock TextWrapping="WrapWithOverflow" VerticalAlignment="Center"
+                                           HorizontalAlignment="Center"
+                                           Text="Möchtest du dieses Mapping als Standardeinstellung übernehmen?" />
                             </materialDesign:Card>
-                            
-                            <StackPanel Grid.Row="1">
-                                <Grid Margin="0, 15, 10, 20">
+                            <Grid Margin="0, 15, 0, 0" Grid.Row="1">
+                                <Grid Grid.Row="1">
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="30" />
                                         <ColumnDefinition Width="*" />
                                         <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
-                                    <materialDesign:PackIcon Grid.Column="0"
-                                                             Kind="Folder" HorizontalAlignment="Center"
-                                                             VerticalAlignment="Center" />
-                                
-                                    <Grid Grid.Column="1">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="Auto" />
-                                        </Grid.ColumnDefinitions>
-                                        <TextBox Margin="0, 0, 5, 0" Grid.Column="0" x:Name="folderPathTextBox" PreviewMouseUp="OnSelectFolderPath" IsReadOnly="True"
-                                                 materialDesign:HintAssist.Hint="Zielordner" />
-                                        
-                                        <TextBox Focusable="True" Margin="0, 0, 5, 0" Grid.Column="1" x:Name="filenameTextBox"
-                                                 materialDesign:HintAssist.Hint="Dateiname" TextChanged="OnFileNameChanged">
-                                            <TextBox.Text>
-                                                <Binding
-                                                    RelativeSource="{RelativeSource Self}" Path="Text"
-                                                    UpdateSourceTrigger="LostFocus">
-                                                    <Binding.ValidationRules>
-                                                        <validationRules:ValidFileNameValidationRule x:Name="validFileNameValidationRule" ValidatesOnTargetUpdated="True" />
-                                                    </Binding.ValidationRules>
-                                                </Binding>
-                                            </TextBox.Text>
-                                        </TextBox>
-                                        
-                                        <TextBox Grid.Column="2" Text=".mp4" x:Name="fileEndingTextBox" IsEnabled="false" IsReadOnly="True" materialDesign:HintAssist.Hint="Format" />
-                                    </Grid>
-                                </Grid>
-                                <!-- Ask later questions -->
-                                <Grid x:Name="targetSizeQuestionParent">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="30" />
                                         <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
-                                    <materialDesign:PackIcon Margin="0, 0, 5, 20" Grid.Column="0"
-                                                             Kind="Numbers" HorizontalAlignment="Center"
-                                                             VerticalAlignment="Center" />
-                                
-                                    <TextBox x:Name="targetSizeTextbox" Grid.Column="1" Margin="0, 0, 10, 20"
-                                             materialDesign:HintAssist.Hint="Zielgröße der Datei"
-                                             TextChanged="TargetSizeTextbox_OnTextChanged">
-                                        <TextBox.Text>
-                                            <Binding
-                                                RelativeSource="{RelativeSource Self}" Path="Text"
-                                                UpdateSourceTrigger="LostFocus">
-                                                <Binding.ValidationRules>
-                                                    <validationRules:IsDigitValidationRule x:Name="isDigitValidationRule" ValidatesOnTargetUpdated="True" />
-                                                </Binding.ValidationRules>
-                                            </Binding>
-                                        </TextBox.Text>
-                                    </TextBox>
+                                    <TextBlock x:Name="directorySuggestionTextBox" Grid.Column="0" Text="F:Videos\Battlefield V\" />
+                                    <materialDesign:PackIcon Margin="5, 0, 5, 0" Grid.Column="1" Kind="ArrowRight" />
+                                    <TextBlock x:Name="mappedDirectorySuggestionTextBox" Grid.Column="2" Text="F:Videos\Mapping\" />
                                 </Grid>
-                                <!-- Control buttons -->
-                                <StackPanel HorizontalAlignment="Right" Margin="0, 0, 10, 10" Orientation="Horizontal">
-                                    <Button x:Name="dialogCompressButton" Click="DialogCompress_OnClick" Margin="0, 0, 5, 0">
-                                        <StackPanel Orientation="Horizontal">
-                                            <materialDesign:PackIcon VerticalAlignment="Center" HorizontalAlignment="Center" Kind="Compress" />
-                                            <TextBlock Text="Komprimiere..."></TextBlock>
-                                        </StackPanel>
-                                    </Button>
-                                    <Button Click="DialogCancel_OnClick">
-                                        <StackPanel Orientation="Horizontal">
-                                            <materialDesign:PackIcon VerticalAlignment="Center" HorizontalAlignment="Center" Kind="Close" />
-                                            <TextBlock Text="Abbrechen"></TextBlock>
-                                        </StackPanel>
-                                    </Button>
-                                </StackPanel>
-                            </StackPanel>
-                            
+                            </Grid>
+                            <Grid VerticalAlignment="Bottom" Grid.Row="2" Margin="0, 15, 0, 5">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition />
+                                    <ColumnDefinition />
+                                </Grid.ColumnDefinitions>
+                                <Button Click="MappingConfirm_OnClick" Margin="0, 0, 2.5, 0" Grid.Column="0">
+                                    <TextBlock Text="Ja"/>
+                                </Button>
+                                <Button Click="MappingCancel_OnClick" Margin="2.5, 0, 0, 0" Grid.Column="1">
+                                    <TextBlock Text="Nein"/>
+                                </Button>
+                            </Grid>
                         </Grid>
                     </materialDesign:Card>
                 </Grid>
             </materialDesign:Card>
+
+        </Grid>
+    </materialDesign:Card>
 </UserControl>

--- a/ContentControls/Dialogs/CompressOptionDialog.xaml.cs
+++ b/ContentControls/Dialogs/CompressOptionDialog.xaml.cs
@@ -16,6 +16,7 @@ using VideoCompressorGUI.ContentControls.Settingspages.PathRulesSettingsTab;
 using VideoCompressorGUI.ffmpeg;
 using VideoCompressorGUI.Settings;
 using VideoCompressorGUI.Utils;
+using VideoCompressorGUI.Utils.Logger;
 
 namespace VideoCompressorGUI.ContentControls.Dialogs
 {
@@ -133,7 +134,7 @@ namespace VideoCompressorGUI.ContentControls.Dialogs
 
                 if (generalSettings.DeleteOriginalFileAfterCompress)
                 {
-                    Console.WriteLine("Move file to Bin: " + file.File);
+                    Log.Info("Move file to Bin: " + file.File);
                     FileSystem.DeleteFile(file.File, UIOption.OnlyErrorDialogs, RecycleOption.SendToRecycleBin,
                         UICancelOption.DoNothing);
                 }

--- a/ContentControls/Dialogs/CompressOptionDialog.xaml.cs
+++ b/ContentControls/Dialogs/CompressOptionDialog.xaml.cs
@@ -11,7 +11,6 @@ using Microsoft.VisualBasic.FileIO;
 using Ookii.Dialogs.Wpf;
 using VideoCompressorGUI.CompressPresets;
 using VideoCompressorGUI.ContentControls.Components;
-using VideoCompressorGUI.ContentControls.Settingspages;
 using VideoCompressorGUI.ContentControls.Settingspages.PathRulesSettingsTab;
 using VideoCompressorGUI.ffmpeg;
 using VideoCompressorGUI.Settings;
@@ -195,13 +194,25 @@ namespace VideoCompressorGUI.ContentControls.Dialogs
             filenameTextBox.Text = "";
             targetSizeTextbox.Text = "";
 
+            this.mappingSuggestion.Visibility = Visibility.Collapsed;
             this.Visibility = Visibility.Collapsed;
         }
 
         private void OnSelectFolderPath(object sender, MouseButtonEventArgs e)
         {
             string newPath = SelectPath();
+            string folderPath = Path.GetDirectoryName(currentlySelectedVideoFile.File);
             folderPathTextBox.Text = newPath == "" && folderPathTextBox.Text != "" ? folderPathTextBox.Text : newPath;
+            
+            
+            if (!pathRuleCollection.ContainsDirectory(folderPath, out string s))
+            {
+                // Mapping not in use. make suggestion
+                mappingSuggestion.Visibility = Visibility.Visible;
+                
+                directorySuggestionTextBox.Text = folderPath;
+                mappedDirectorySuggestionTextBox.Text = folderPathTextBox.Text;
+            }
         }
 
         private bool ValidateCanCompress()
@@ -233,6 +244,22 @@ namespace VideoCompressorGUI.ContentControls.Dialogs
             }
 
             return "";
+        }
+
+        private void MappingConfirm_OnClick(object sender, RoutedEventArgs e)
+        {
+            string dir = directorySuggestionTextBox.Text;
+            string mappedDir = mappedDirectorySuggestionTextBox.Text;
+            
+            pathRuleCollection.Add(new PathRule(dir, mappedDir));
+            SettingsFolder.Save(pathRuleCollection);
+            
+            mappingSuggestion.Visibility = Visibility.Collapsed;
+        }
+
+        private void MappingCancel_OnClick(object sender, RoutedEventArgs e)
+        {
+            mappingSuggestion.Visibility = Visibility.Collapsed;
         }
     }
 }

--- a/ContentControls/Dialogs/CompressOptionDialog.xaml.cs
+++ b/ContentControls/Dialogs/CompressOptionDialog.xaml.cs
@@ -9,11 +9,10 @@ using System.Windows.Media.Animation;
 using ffmpegCompressor;
 using Microsoft.VisualBasic.FileIO;
 using Ookii.Dialogs.Wpf;
-using VideoCompressorGUI.CompressPresets;
 using VideoCompressorGUI.ContentControls.Components;
 using VideoCompressorGUI.ContentControls.Settingspages.PathRulesSettingsTab;
 using VideoCompressorGUI.ffmpeg;
-using VideoCompressorGUI.Settings;
+using VideoCompressorGUI.SettingsLoadables;
 using VideoCompressorGUI.Utils;
 using VideoCompressorGUI.Utils.Logger;
 

--- a/ContentControls/DragAndDropWindowControl.xaml.cs
+++ b/ContentControls/DragAndDropWindowControl.xaml.cs
@@ -6,7 +6,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using Ookii.Dialogs.Wpf;
-using VideoCompressorGUI.Settings;
+using VideoCompressorGUI.SettingsLoadables;
 using VideoCompressorGUI.Utils;
 
 namespace VideoCompressorGUI.ContentControls

--- a/ContentControls/Settingspages/GeneralSettingsTab/GeneralSettings.xaml.cs
+++ b/ContentControls/Settingspages/GeneralSettingsTab/GeneralSettings.xaml.cs
@@ -24,6 +24,8 @@ namespace VideoCompressorGUI.ContentControls.Settingspages.GeneralSettingsTab
             var settingsLoad = SettingsFolder.Load<GeneralSettingsData>();
 
             ApplySettingsLoad(settingsLoad);
+
+            throw new Exception("ROFL");
         }
 
         private void ApplySettingsLoad(GeneralSettingsData settings)

--- a/ContentControls/Settingspages/GeneralSettingsTab/GeneralSettings.xaml.cs
+++ b/ContentControls/Settingspages/GeneralSettingsTab/GeneralSettings.xaml.cs
@@ -24,8 +24,6 @@ namespace VideoCompressorGUI.ContentControls.Settingspages.GeneralSettingsTab
             var settingsLoad = SettingsFolder.Load<GeneralSettingsData>();
 
             ApplySettingsLoad(settingsLoad);
-
-            throw new Exception("ROFL");
         }
 
         private void ApplySettingsLoad(GeneralSettingsData settings)

--- a/ContentControls/Settingspages/GeneralSettingsTab/GeneralSettings.xaml.cs
+++ b/ContentControls/Settingspages/GeneralSettingsTab/GeneralSettings.xaml.cs
@@ -3,7 +3,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using Ookii.Dialogs.Wpf;
-using VideoCompressorGUI.Settings;
+using VideoCompressorGUI.SettingsLoadables;
 
 namespace VideoCompressorGUI.ContentControls.Settingspages.GeneralSettingsTab
 {

--- a/ContentControls/Settingspages/InfoTab/AboutSettings.xaml.cs
+++ b/ContentControls/Settingspages/InfoTab/AboutSettings.xaml.cs
@@ -1,5 +1,3 @@
-using System;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
@@ -47,35 +45,35 @@ namespace VideoCompressorGUI.ContentControls.Settingspages.InfoTab
             if (!updateNext)
             {
                 GithubReleaseCheck checker = new GithubReleaseCheck();
-                GithubResponse response = await checker.FetchData();
-
                 SetButtonLoadingAnimation(true);
+
+                GithubResponse response = await checker.FetchData();
                 
                 if (checker.Check())
                 {
+                    this.newUpdateAvailableTextBlock.Text = response.ChangeLogs;
+                    
                     checker.OnDownloadFinished += () =>
                     {
-                        this.newUpdateAvailableTextBlock.Text = response.ChangeLogs;
                         SetButtonLoadingAnimation(false);
+                        updateButton.Content = "Update durchführen (Neustart erforderlich)";
+                        updateNext = true;
                     };
                     
                     await checker.DownloadNewest();
-                
-                    updateButton.Content = "Update durchführen (Neustart erforderlich)";
-                    updateNext = true;
+                }
+                else
+                {
+                    
+                    SetButtonLoadingAnimation(false);
                 }
             }
             else
             {
-                // Code, für den Fall, dass das Update durchgeführt werden soll
                 // https://stackoverflow.com/questions/22891580/update-c-sharp-application-replace-exe-file
-                // 1) File.Delete any previous .bak files
                 DeleteOldFiles();
-                // 2) Move files by renaming them to "*_OLD.*"
                 MoveFiles();
-                // 3)
                 CopyUpdateFiles();
-                // 4)
                 RestartApplication();
             }
         }

--- a/ContentControls/Settingspages/PathRulesSettingsTab/PathRule.cs
+++ b/ContentControls/Settingspages/PathRulesSettingsTab/PathRule.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using VideoCompressorGUI.Settings;
+using VideoCompressorGUI.SettingsLoadables;
 
 namespace VideoCompressorGUI.ContentControls.Settingspages.PathRulesSettingsTab
 {

--- a/ContentControls/Settingspages/PathRulesSettingsTab/PathRulesSettings.xaml.cs
+++ b/ContentControls/Settingspages/PathRulesSettingsTab/PathRulesSettings.xaml.cs
@@ -7,7 +7,7 @@ using System.Windows.Media;
 using MaterialDesignThemes.Wpf;
 using Ookii.Dialogs.Wpf;
 using VideoCompressorGUI.ContentControls.Settingspages.PathRulesSettingsTab;
-using VideoCompressorGUI.Settings;
+using VideoCompressorGUI.SettingsLoadables;
 
 namespace VideoCompressorGUI.ContentControls.Settingspages
 {

--- a/ContentControls/Settingspages/PresetsSettingsTab/PresetsSettings.xaml.cs
+++ b/ContentControls/Settingspages/PresetsSettingsTab/PresetsSettings.xaml.cs
@@ -4,9 +4,8 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 using MaterialDesignThemes.Wpf;
-using VideoCompressorGUI.CompressPresets;
 using VideoCompressorGUI.ContentControls.Components;
-using VideoCompressorGUI.Settings;
+using VideoCompressorGUI.SettingsLoadables;
 
 namespace VideoCompressorGUI.ContentControls.Settingspages
 {
@@ -109,6 +108,7 @@ namespace VideoCompressorGUI.ContentControls.Settingspages
 
             savingButton.IsEnabled = true;
             deleteButton.Visibility = Visibility.Visible;
+            deleteButton.IsEnabled = this.compressPresetCollection.CompressPresets.Count > 1;
 
             buttonNewPresetItem.Background = Brushes.White;
             buttonNewPresetItem.BorderBrush = Brushes.White;

--- a/ContentControls/VideoEditorWindowControl.xaml
+++ b/ContentControls/VideoEditorWindowControl.xaml
@@ -14,6 +14,7 @@
              TextOptions.TextRenderingMode="Auto"
              d:DesignHeight="900" d:DesignWidth="1600"
              Loaded="VideoEditorControl_OnLoaded"
+             Unloaded="VideoEditorControl_OnUnloaded"
              Background="{DynamicResource MaterialDesignPaper}"
              FontFamily="{DynamicResource MaterialDesignFont}">
     <Grid>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -8,7 +8,7 @@ using System.Windows.Input;
 using VideoCompressorGUI.ContentControls;
 using VideoCompressorGUI.ContentControls.Settingspages;
 using VideoCompressorGUI.ContentControls.Settingspages.InfoTab;
-using VideoCompressorGUI.Settings;
+using VideoCompressorGUI.SettingsLoadables;
 
 namespace VideoCompressorGUI
 {

--- a/Settings/SettingsFolder.cs
+++ b/Settings/SettingsFolder.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
 using VideoCompressorGUI.CompressPresets;
-using VideoCompressorGUI.ContentControls.Settingspages;
 using VideoCompressorGUI.ContentControls.Settingspages.PathRulesSettingsTab;
+using VideoCompressorGUI.Utils.Logger;
 
 namespace VideoCompressorGUI.Settings
 {
@@ -77,7 +77,7 @@ namespace VideoCompressorGUI.Settings
 
             if (string.IsNullOrWhiteSpace(content))
             {
-                Console.WriteLine($"No configuration loaded for: {typeof(T)}. Load standard config");
+                Log.Info($"No configuration loaded for: {typeof(T)}. Load standard config");
                 return value.CreateDefault();
             }
 
@@ -90,8 +90,8 @@ namespace VideoCompressorGUI.Settings
             string json = JsonConvert.SerializeObject(value, Formatting.Indented);
 
             Console.ForegroundColor = ConsoleColor.Green;
-            Console.WriteLine($"Saving to: {path}");
-            Console.WriteLine(json);
+            Log.Info($"Saving to: {path}");
+            Log.Info(json);
             Console.ResetColor();
 
             File.WriteAllText(path, json);

--- a/SettingsLoadables/CompressPreset.cs
+++ b/SettingsLoadables/CompressPreset.cs
@@ -1,4 +1,4 @@
-namespace VideoCompressorGUI.CompressPresets
+namespace VideoCompressorGUI.SettingsLoadables
 {
     [System.Serializable]
     public class CompressPreset

--- a/SettingsLoadables/CompressPresetCollection.cs
+++ b/SettingsLoadables/CompressPresetCollection.cs
@@ -1,8 +1,7 @@
 using System;
 using System.Collections.Generic;
-using VideoCompressorGUI.Settings;
 
-namespace VideoCompressorGUI.CompressPresets
+namespace VideoCompressorGUI.SettingsLoadables
 {
     [System.Serializable]
     public class CompressPresetCollection : ISettingsLoadable<CompressPresetCollection>
@@ -31,6 +30,25 @@ namespace VideoCompressorGUI.CompressPresets
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Gets the preset by name
+        /// </summary>
+        /// <returns>Return preset with corresponding name. If not found, it will return the first preset</returns>
+        public CompressPreset GetByName(string cacheLatestSelectedPresetName)
+        {
+            CompressPreset preset = this.CompressPresets[0];
+
+            for (int i = 0; i < this.CompressPresets.Count; i++)
+            {
+                if (this.CompressPresets[i].PresetName.ToLower() == cacheLatestSelectedPresetName.ToLower())
+                {
+                    return this.CompressPresets[i];
+                }
+            }
+
+            return preset;
         }
     }
 }

--- a/SettingsLoadables/GeneralSettingsData.cs
+++ b/SettingsLoadables/GeneralSettingsData.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 
-namespace VideoCompressorGUI.Settings
+namespace VideoCompressorGUI.SettingsLoadables
 {
     [System.Serializable]
     public class GeneralSettingsData : ISettingsLoadable<GeneralSettingsData>

--- a/SettingsLoadables/ISettingsLoadable.cs
+++ b/SettingsLoadables/ISettingsLoadable.cs
@@ -1,4 +1,4 @@
-namespace VideoCompressorGUI.Settings
+namespace VideoCompressorGUI.SettingsLoadables
 {
     public interface ISettingsLoadable<T>
     {

--- a/SettingsLoadables/SettingsFolder.cs
+++ b/SettingsLoadables/SettingsFolder.cs
@@ -2,11 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
-using VideoCompressorGUI.CompressPresets;
 using VideoCompressorGUI.ContentControls.Settingspages.PathRulesSettingsTab;
 using VideoCompressorGUI.Utils.Logger;
 
-namespace VideoCompressorGUI.Settings
+namespace VideoCompressorGUI.SettingsLoadables
 {
     public class SettingsFolder
     {
@@ -42,6 +41,12 @@ namespace VideoCompressorGUI.Settings
                     typeof(PathRuleCollection), new Dictionary<string, string>
                     {
                         { "", nameof(PathRuleCollection) + ".json" }
+                    }
+                },
+                {
+                    typeof(VideoEditorCache), new Dictionary<string, string>
+                    {
+                        { "", nameof(VideoEditorCache) + ".json" }
                     }
                 },
             };

--- a/SettingsLoadables/VideoEditorCache.cs
+++ b/SettingsLoadables/VideoEditorCache.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace VideoCompressorGUI.SettingsLoadables
+{
+    [System.Serializable]
+    public class VideoEditorCache : ISettingsLoadable<VideoEditorCache>
+    {
+        public string LatestSelectedPresetName { get; set; }
+        
+        public VideoEditorCache CreateDefault()
+        {
+            return new VideoEditorCache
+            {
+                LatestSelectedPresetName = "Discord"
+            };
+        }
+    }
+}

--- a/SettingsLoadables/VideoPlayerCache.cs
+++ b/SettingsLoadables/VideoPlayerCache.cs
@@ -1,4 +1,4 @@
-namespace VideoCompressorGUI.Settings
+namespace VideoCompressorGUI.SettingsLoadables
 {
     public class VideoPlayerCache : ISettingsLoadable<VideoPlayerCache>
     {

--- a/Utils/ClassExtensions.cs
+++ b/Utils/ClassExtensions.cs
@@ -10,7 +10,7 @@ using System.Windows.Media.Animation;
 using System.Windows.Threading;
 using FFmpeg.NET;
 using MaterialDesignThemes.Wpf;
-using VideoCompressorGUI.CompressPresets;
+using VideoCompressorGUI.SettingsLoadables;
 
 namespace VideoCompressorGUI.Utils
 {
@@ -116,15 +116,13 @@ namespace VideoCompressorGUI.Utils
             return from;
         }
 
-        public static ConversionOptions BuildConversionOptions(this Engine ffmpeg, VideoFileMetaData file, CompressPreset preset)
+        public static ConversionOptions BuildConversionOptions(this Engine ffmpeg, VideoFileMetaData file, CompressPreset preset, TimeSpan snippetLength)
         {
             ConversionOptions options = new ConversionOptions
             {
-                VideoBitRate = preset.UseTargetSizeCalculation ? preset.CalculateBitrateWithFixedTargetSize(file.MetaData.Duration.TotalSeconds) : preset.Bitrate,
+                VideoBitRate = preset.UseTargetSizeCalculation ? preset.CalculateBitrateWithFixedTargetSize(snippetLength.TotalSeconds) : preset.Bitrate,
                 VideoFps = (int) file.MetaData.VideoData.Fps,
             };
-        
-            // options.CutMedia();
 
             return options;
         }

--- a/Utils/Github/GithubReleaseCheck.cs
+++ b/Utils/Github/GithubReleaseCheck.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using VideoCompressorGUI.ContentControls.Settingspages.InfoTab;
+using VideoCompressorGUI.Utils.Logger;
 
 namespace VideoCompressorGUI.Utils.Github
 {
@@ -56,7 +57,7 @@ namespace VideoCompressorGUI.Utils.Github
             }
             catch (Exception e)
             {
-                Console.WriteLine(e.Message);
+                Log.Warn(e.Message);
                 return null;
             }
         }

--- a/Utils/Logger/Log.cs
+++ b/Utils/Logger/Log.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace VideoCompressorGUI.Utils.Logger
+{
+    public class Log
+    {
+        private object mutex = new();
+        private string relativePath;
+        private string fullPath;
+        private static Log instance;
+        
+        
+        public bool LogToConsole { get; set; }
+        public bool LogToFile { get; set; }
+
+        public string RelativePath
+        {
+            get => relativePath;
+            set
+            {
+                relativePath = value;
+                fullPath = Path.GetDirectoryName(typeof(Log).Assembly.Location) + RelativePath;
+                Directory.CreateDirectory(fullPath);
+            }
+        }
+        public DateTime ApplicationStarted { get; private set; }
+
+        public Log()
+        {
+            this.LogToConsole = true;
+            this.LogToFile = true;
+            this.RelativePath = "\\logs\\";
+            instance = this;
+            
+            this.ApplicationStarted = DateTime.Now;
+            
+            
+        }
+
+        public void WarnPrint(string message)
+        {
+            lock (mutex)
+            {
+                if (LogToConsole)
+                    Console.WriteLine(message);
+                
+                if (LogToFile && fullPath != "")
+                    WriteFile(message);
+            }
+        }
+
+        public static void Warn(string message)
+            => instance.WarnPrint(message);
+        
+        public static void Info(string message)
+            => instance.InfoPrint(message);
+        
+        public void InfoPrint(string message)
+        {
+            lock (mutex)
+            {
+                if (LogToConsole)
+                    Console.WriteLine(message);
+                
+                if (LogToFile && fullPath != "")
+                    WriteFile(message);
+            }
+        }
+
+        public void Error(Exception ex, bool logToConsole = false)
+        {
+            StringBuilder builder = new StringBuilder();
+            builder.Append("====== ERROR: ==").Append(DateTime.Now.ToShortTimeString()).Append("==============\n");
+            builder.Append("Message:\n\n").Append(ex.Message);
+            builder.Append("\nInner message:\n\n").Append(ex.InnerException);
+            builder.Append("\nStack trace:\n\n").Append(ex.StackTrace);
+            builder.Append("\n\n\n\n");
+
+            string bu = builder.ToString();
+
+            lock (mutex)
+            {
+                if (LogToConsole && logToConsole)
+                    Console.WriteLine(bu);
+
+
+                if (LogToFile && fullPath != "")
+                    WriteFile(bu);
+            }
+        }
+
+        private void WriteFile(string message)
+        {
+            string logPath = fullPath + ApplicationStarted.ToFileTime()  + ".log";
+            using StreamWriter sw = File.AppendText(logPath);
+            sw.Write(message);
+        }
+    }
+}

--- a/Utils/TempFolder.cs
+++ b/Utils/TempFolder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Text;
+using VideoCompressorGUI.Utils.Logger;
 
 namespace VideoCompressorGUI.Utils
 {
@@ -25,7 +26,7 @@ namespace VideoCompressorGUI.Utils
                 if (DateTime.Now - file.CreationTime > TimeSpan.FromDays(7))
                 {
                     cleanup = true;
-                    Console.WriteLine("Clean up temp folder");
+                    Log.Info("Clean up temp folder");
                     break;
                 }
             }

--- a/VideoCompressorGUI.csproj
+++ b/VideoCompressorGUI.csproj
@@ -31,4 +31,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="CompressPresets" />
+  </ItemGroup>
+
 </Project>

--- a/WPFCustomBehaviours/ValidationRules/ZeroToEightLengthValidationRule.cs
+++ b/WPFCustomBehaviours/ValidationRules/ZeroToEightLengthValidationRule.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Globalization;
 using System.Windows.Controls;
-using VideoCompressorGUI.CompressPresets;
+using VideoCompressorGUI.SettingsLoadables;
 
 namespace VideoCompressorGUI.WPFCustomBehaviours.ValidationRules
 {

--- a/ffmpeg/Compressor.cs
+++ b/ffmpeg/Compressor.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using FFmpeg.NET;
-using VideoCompressorGUI.CompressPresets;
+using VideoCompressorGUI.SettingsLoadables;
 using VideoCompressorGUI.Utils;
 
 namespace VideoCompressorGUI.ffmpeg
@@ -66,12 +66,13 @@ namespace VideoCompressorGUI.ffmpeg
         {
             InputFile inputFile = new InputFile(videoFile.File);
             OutputFile outputFile = new OutputFile(compressOptions.OutputPath);
-        
-            ConversionOptions options = this.ffmpeg.BuildConversionOptions(videoFile, preset);
+            TimeSpan snippetLength = (videoFile.CutSeek.End - videoFile.CutSeek.Start);
+            
+            ConversionOptions options = this.ffmpeg.BuildConversionOptions(videoFile, preset, snippetLength);
 
             if (videoFile.CutSeek != null)
             {
-                options.CutMedia(videoFile.CutSeek.Start, (videoFile.CutSeek.End - videoFile.CutSeek.Start));
+                options.CutMedia(videoFile.CutSeek.Start, snippetLength);
             }
         
             this.ffmpeg.Progress += (_, args) =>


### PR DESCRIPTION
# Changelog 0.0.0.3
- Logger hinzufügt
- Überarbeitete Video range slider UI
- Besserte Video Slider UI
- Wenn der Nutzer in den "Letzte Komprimieroptionen" einen anderen Pfad auswählt, und dieser noch kein Mapping hat, wird der Nutzer gefragt, ob dieses Mapping zu den Regeln hinzufügt werden soll.
- Speichert den unten rechts ausgewählten Preset
- Snippetauswahl wird zurückgesetzt, sobald ein neues Video ausgewählt wird
## Bugfixes
  - Es gibt nun keine Möglichkeit mehr, das einzige Preset zu löschen
  - "#6 - Fixed Target size calculation is wrong" behoben